### PR TITLE
build: add missing external dependencies for react bindings

### DIFF
--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -21,7 +21,7 @@ export default defineConfig([
   },
   {
     input: 'src/react-bindings/index.ts',
-    external: ['@wendellhu/redi'],
+    external: ['@wendellhu/redi', 'react', 'react/jsx-runtime'],
     output: {
       format: 'esm',
       dir: 'dist/react-bindings',
@@ -31,7 +31,7 @@ export default defineConfig([
   },
   {
     input: 'src/react-bindings/index.ts',
-    external: ['@wendellhu/redi'],
+    external: ['@wendellhu/redi', 'react', 'react/jsx-runtime'],
     output: {
       file: 'dist/react-bindings/index.js',
       format: 'cjs',


### PR DESCRIPTION
The Rolldown configuration does not exclude `react`

![image](https://github.com/user-attachments/assets/c1838eae-9cc5-439e-9c1e-56c0117f3f24)
