### PR TITLE
feat: implement global lock mechanism and enhance idle callback handling

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -9,3 +9,8 @@ coverageReporter = [
   "lcov"
 ]
 coverageDir = "coverage"
+coveragePathIgnorePatterns = [
+  "happydom.ts",
+  "src/__testing__/**",
+]
+coverageThreshold = { line = 1.0, function = 1.0 }

--- a/src/__tests__/globalLock.spec.ts
+++ b/src/__tests__/globalLock.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'bun:test';
+import { acquireGlobalLock, detectGlobalEnv } from '../globalLock';
+
+describe('globalLock', () => {
+  it('sets the lock the first time and returns true', () => {
+    const globalObject: Record<string, unknown> = {};
+    let warned: string | undefined;
+    const acquired = acquireGlobalLock('LOCK', 'duplicate!', {
+      globalObject,
+      isNode: false,
+      warn: (m) => {
+        warned = m;
+      },
+    });
+
+    expect(acquired).toBe(true);
+    expect(globalObject.LOCK).toBe(true);
+    expect(warned).toBeUndefined();
+  });
+
+  it('warns and returns false in browsers when already locked', () => {
+    const globalObject: Record<string, unknown> = { LOCK: true };
+    let warned: string | undefined;
+    const acquired = acquireGlobalLock('LOCK', 'duplicate!', {
+      globalObject,
+      isNode: false,
+      warn: (m) => {
+        warned = m;
+      },
+    });
+
+    expect(acquired).toBe(false);
+    expect(warned).toBe('duplicate!');
+  });
+
+  it('stays silent in Node when already locked', () => {
+    const globalObject: Record<string, unknown> = { LOCK: true };
+    let warned: string | undefined;
+    const acquired = acquireGlobalLock('LOCK', 'duplicate!', {
+      globalObject,
+      isNode: true,
+      warn: (m) => {
+        warned = m;
+      },
+    });
+
+    expect(acquired).toBe(false);
+    expect(warned).toBeUndefined();
+  });
+
+  it('detectGlobalEnv returns a usable environment', () => {
+    const env = detectGlobalEnv();
+    expect(env.globalObject).toBeDefined();
+    expect(typeof env.isNode).toBe('boolean');
+    expect(typeof env.warn).toBe('function');
+  });
+});

--- a/src/__tests__/idle.spec.ts
+++ b/src/__tests__/idle.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { wait } from '../__testing__/timer';
-import { IdleValue } from '../idleValue';
+import { createRunWhenIdle, IdleValue } from '../idleValue';
 
 describe('test idle', () => {
   it('should run when idle', () => {
@@ -49,5 +49,64 @@ describe('test idle', () => {
     expect(executed).toBe(false);
     expect(idleValue.getValue()).toBe(42);
     expect(executed).toBe(true);
+  });
+
+  describe('createRunWhenIdle', () => {
+    it('uses requestIdleCallback when available', () => {
+      let scheduled: ((d: any) => void) | undefined;
+      let cancelled: number | undefined;
+      const runner = createRunWhenIdle({
+        requestIdleCallback: (cb) => {
+          scheduled = cb;
+          return 7;
+        },
+        cancelIdleCallback: (handle) => {
+          cancelled = handle;
+        },
+      });
+
+      let ran = false;
+      const dispose = runner(() => {
+        ran = true;
+      }, 100);
+      scheduled!({ didTimeout: false, timeRemaining: () => 10 });
+      expect(ran).toBe(true);
+
+      dispose();
+      expect(cancelled).toBe(7);
+
+      // second dispose is a no-op
+      cancelled = undefined;
+      dispose();
+      expect(cancelled).toBeUndefined();
+    });
+
+    it('falls back to setTimeout when requestIdleCallback is missing', async () => {
+      const runner = createRunWhenIdle({});
+      let received: any;
+      const dispose = runner((idle) => {
+        received = idle;
+      });
+
+      await wait(10);
+      expect(received?.didTimeout).toBe(true);
+      expect(received?.timeRemaining()).toBe(15);
+
+      // disposing after the timer fired is still safe
+      dispose();
+      dispose();
+    });
+
+    it('clears the fallback timer on dispose', async () => {
+      const runner = createRunWhenIdle({});
+      let ran = false;
+      const dispose = runner(() => {
+        ran = true;
+      });
+
+      dispose();
+      await wait(10);
+      expect(ran).toBe(false);
+    });
   });
 });

--- a/src/__tests__/reactComponent.spec.tsx
+++ b/src/__tests__/reactComponent.spec.tsx
@@ -1,0 +1,84 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'bun:test';
+import React from 'react';
+import { createIdentifier } from '../decorators';
+import { Injector } from '../injector';
+import {
+  connectDependencies,
+  connectInjector,
+} from '../react-bindings/reactComponent';
+import { useDependency } from '../react-bindings/reactHooks';
+
+interface IGreeting {
+  hello: () => string;
+}
+// eslint-disable-next-line ts/no-redeclare
+const IGreeting = createIdentifier<IGreeting>('IGreeting');
+
+function Greeter() {
+  const greeting = useDependency(IGreeting);
+  return <span>{greeting.hello()}</span>;
+}
+
+describe('react component bindings', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('connectInjector provides the supplied injector to children', () => {
+    const injector = new Injector([
+      [IGreeting, { useValue: { hello: () => 'from-injector' } }],
+    ]);
+    const App = connectInjector(Greeter, injector);
+
+    const { container } = render(<App />);
+    expect(container.textContent).toBe('from-injector');
+  });
+
+  it('connectDependencies reuses the cached child injector across re-renders', () => {
+    const App = connectDependencies(Greeter, [
+      [IGreeting, { useValue: { hello: () => 'cached' } }],
+    ]);
+
+    const { container, rerender } = render(<App />);
+    expect(container.textContent).toBe('cached');
+
+    rerender(<App />);
+    expect(container.textContent).toBe('cached');
+  });
+
+  it('connectDependencies creates a child injector when nested inside another', () => {
+    interface IOuter {
+      tag: string;
+    }
+    // eslint-disable-next-line ts/no-redeclare
+    const IOuter = createIdentifier<IOuter>('IOuter');
+
+    function Combined() {
+      const outer = useDependency(IOuter);
+      const greeting = useDependency(IGreeting);
+      return <span>{`${outer.tag}-${greeting.hello()}`}</span>;
+    }
+
+    const Inner = connectDependencies(Combined, [
+      [IGreeting, { useValue: { hello: () => 'inner' } }],
+    ]);
+    const Outer = connectDependencies(Inner, [
+      [IOuter, { useValue: { tag: 'outer' } }],
+    ]);
+
+    const { container } = render(<Outer />);
+    expect(container.textContent).toBe('outer-inner');
+  });
+
+  it('disposes the child injector when unmounted', () => {
+    const App = connectDependencies(Greeter, [
+      [IGreeting, { useValue: { hello: () => 'bye' } }],
+    ]);
+
+    const { container, unmount } = render(<App />);
+    expect(container.textContent).toBe('bye');
+
+    unmount();
+  });
+});

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -39,7 +39,7 @@ export class IdentifierUndefinedError extends RediError {
       index
     }th parameter of "${prettyPrintIdentifier(
       target,
-    )}". Please make sure that there is not cyclic dependency among your TypeScript files, or consider using "forwardRef". For more info please visit our website https://redi.wendell.fun/docs/faq#could-not-find-dependency-registered-on`;
+    )}". Please make sure that there is not cyclic dependency among your TypeScript files, or consider using "forwardRef". For more info please visit our website https://redi.wzhu.dev/docs/faq#could-not-find-dependency-registered-on`;
 
     super(msg);
   }

--- a/src/globalLock.ts
+++ b/src/globalLock.ts
@@ -1,0 +1,42 @@
+/* eslint-disable node/prefer-global/process */
+
+export interface GlobalLockEnv {
+  globalObject: Record<string, unknown>;
+  isNode: boolean;
+  warn: (message: string) => void;
+}
+
+export function detectGlobalEnv(): GlobalLockEnv {
+  const globalObject: any =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    // eslint-disable-next-line no-restricted-globals
+    (typeof global !== 'undefined' && global);
+
+  const isNode =
+    typeof process !== 'undefined' &&
+    process.versions != null &&
+    process.versions.node != null;
+
+  return {
+    globalObject,
+    isNode,
+    warn: (message) => console.error(message),
+  };
+}
+
+export function acquireGlobalLock(
+  key: string,
+  duplicateMessage: string,
+  env: GlobalLockEnv = detectGlobalEnv(),
+): boolean {
+  if (env.globalObject[key]) {
+    if (!env.isNode) {
+      env.warn(duplicateMessage);
+    }
+    return false;
+  }
+
+  env.globalObject[key] = true;
+  return true;
+}

--- a/src/idleValue.ts
+++ b/src/idleValue.ts
@@ -7,34 +7,24 @@ export interface IdleDeadline {
 
 export type DisposableCallback = () => void;
 
-/**
- * this run the callback when CPU is idle. Will fallback to setTimeout if
- * the browser doesn't support requestIdleCallback
- */
-// eslint-disable-next-line import/no-mutable-exports
-export let runWhenIdle: (
+export type RunWhenIdle = (
   callback: (idle?: IdleDeadline) => void,
   timeout?: number,
 ) => DisposableCallback;
 
-// declare global variables because apparently the type file doesn't have it, for now
-declare function requestIdleCallback(
-  callback: (args: IdleDeadline) => void,
-  options?: { timeout: number },
-): number;
-declare function cancelIdleCallback(handle: number): void;
+interface IdleGlobals {
+  requestIdleCallback?: (
+    callback: (args: IdleDeadline) => void,
+    options?: { timeout: number },
+  ) => number;
+  cancelIdleCallback?: (handle: number) => void;
+}
 
-// use an IIFE to set up runWhenIdle
-(function () {
-  // this API is not available in Node.js, so we need to ignore it in tests
-  /* istanbul ignore next -- @preserve */
-  if (
-    typeof requestIdleCallback !== 'undefined' &&
-    typeof cancelIdleCallback !== 'undefined'
-  ) {
-    // use native requestIdleCallback
-    runWhenIdle = (runner, timeout?) => {
-      const handle: number = requestIdleCallback(
+export function createRunWhenIdle(globals: IdleGlobals): RunWhenIdle {
+  const { requestIdleCallback, cancelIdleCallback } = globals;
+  if (requestIdleCallback && cancelIdleCallback) {
+    return (runner, timeout?) => {
+      const handle = requestIdleCallback(
         runner,
         typeof timeout === 'number' ? { timeout } : undefined,
       );
@@ -47,30 +37,36 @@ declare function cancelIdleCallback(handle: number): void;
         cancelIdleCallback(handle);
       };
     };
-  } else {
-    // use setTimeout as hack
-    const dummyIdle: IdleDeadline = Object.freeze({
-      didTimeout: true,
-      /* istanbul ignore next */
-      timeRemaining() {
-        return 15;
-      },
-    });
-
-    runWhenIdle = (runner) => {
-      const handle = setTimeout(() => runner(dummyIdle));
-      let disposed = false;
-      return () => {
-        if (disposed) {
-          return;
-        }
-
-        disposed = true;
-        clearTimeout(handle);
-      };
-    };
   }
-})();
+
+  const dummyIdle: IdleDeadline = Object.freeze({
+    didTimeout: true,
+    timeRemaining() {
+      return 15;
+    },
+  });
+
+  return (runner) => {
+    const handle = setTimeout(() => runner(dummyIdle));
+    let disposed = false;
+    return () => {
+      if (disposed) {
+        return;
+      }
+
+      disposed = true;
+      clearTimeout(handle);
+    };
+  };
+}
+
+/**
+ * this run the callback when CPU is idle. Will fallback to setTimeout if
+ * the browser doesn't support requestIdleCallback
+ */
+export const runWhenIdle: RunWhenIdle = createRunWhenIdle(
+  globalThis as IdleGlobals,
+);
 
 /**
  * a wrapper of a executor so it can be evaluated when it's necessary or the CPU is idle

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -1,4 +1,4 @@
-/* eslint-disable node/prefer-global/process */
+import { acquireGlobalLock } from './globalLock';
 
 export { createIdentifier } from './decorators';
 export type { Dependency, DependencyPair } from './dependencyCollection';
@@ -33,24 +33,9 @@ export { type IAccessor, Injector } from './injector';
 export { InjectSelf } from './injectSelf';
 export { LookUp, Quantity } from './types';
 
-const globalObject: any =
-  (typeof globalThis !== 'undefined' && globalThis) ||
-  (typeof window !== 'undefined' && window) ||
-  // eslint-disable-next-line no-restricted-globals
-  (typeof global !== 'undefined' && global);
-
-const __REDI_GLOBAL_LOCK__ = 'REDI_GLOBAL_LOCK';
-const isNode =
-  typeof process !== 'undefined' &&
-  process.versions != null &&
-  process.versions.node != null;
-
-if (globalObject[__REDI_GLOBAL_LOCK__]) {
-  if (!isNode) {
-    console.error(`[redi]: You are loading scripts of redi more than once! This may cause undesired behavior in your application.
+acquireGlobalLock(
+  'REDI_GLOBAL_LOCK',
+  `[redi]: You are loading scripts of redi more than once! This may cause undesired behavior in your application.
 Maybe your dependencies added redi as its dependency and bundled redi to its dist files. Or you import different versions of redi.
-For more info please visit our website: https://redi.wendell.fun/en-US/docs/faq#import-scripts-of-redi-more-than-once`);
-  }
-} else {
-  globalObject[__REDI_GLOBAL_LOCK__] = true;
-}
+For more info please visit our website: https://redi.wzhu.dev/en-US/docs/faq#import-scripts-of-redi-more-than-once`,
+);

--- a/src/react-bindings/publicApi.ts
+++ b/src/react-bindings/publicApi.ts
@@ -1,4 +1,4 @@
-/* eslint-disable node/prefer-global/process */
+import { acquireGlobalLock } from '../globalLock';
 
 export { connectDependencies, connectInjector } from './reactComponent';
 export { RediConsumer, RediContext, RediProvider } from './reactContext';
@@ -6,22 +6,7 @@ export { WithDependency } from './reactDecorators';
 export { useDependency, useInjector } from './reactHooks';
 export * from './reactRx';
 
-const __REDI_CONTEXT_LOCK__ = 'REDI_CONTEXT_LOCK';
-const isNode =
-  typeof process !== 'undefined' &&
-  process.versions != null &&
-  process.versions.node != null;
-
-const globalObject: any =
-  (typeof globalThis !== 'undefined' && globalThis) ||
-  (typeof window !== 'undefined' && window) ||
-  // eslint-disable-next-line no-restricted-globals
-  (typeof global !== 'undefined' && global);
-
-if (!globalObject[__REDI_CONTEXT_LOCK__]) {
-  globalObject[__REDI_CONTEXT_LOCK__] = true;
-} else if (!isNode) {
-  console.error(
-    '[redi]: "RediContext" is already created. You may import "RediContext" from different paths. Use "import { RediContext } from \'@wendellhu/redi/react-bindings\'; instead."',
-  );
-}
+acquireGlobalLock(
+  'REDI_CONTEXT_LOCK',
+  '[redi]: "RediContext" is already created. You may import "RediContext" from different paths. Use "import { RediContext } from \'@wendellhu/redi/react-bindings\'; instead."',
+);


### PR DESCRIPTION
- Added a new `globalLock.ts` file to manage global locking functionality, preventing multiple instances of the library from being loaded.
- Updated `publicApi.ts` and `react-bindings/publicApi.ts` to utilize the new global lock.
- Refactored `idleValue.ts` to create a `createRunWhenIdle` function that supports both `requestIdleCallback` and a fallback to `setTimeout`.
- Introduced tests for the global lock and idle callback functionality to ensure correct behavior.
- Updated coverage settings in `bunfig.toml` to ignore specific paths and set coverage thresholds.