### PR TITLE
fix: respect `useExisting` items in `Injector.add()` (closes #56)

### DIFF
--- a/src/__tests__/core.spec.ts
+++ b/src/__tests__/core.spec.ts
@@ -580,6 +580,26 @@ describe('core', () => {
         expect(j.get(b)).toBe(j.get(A));
         expect(initCount).toBe(1);
       });
+
+      it('should resolve as an alias when registered via `Injector.add`', () => {
+        let initCount = 0;
+
+        class A {
+          constructor() {
+            initCount += 1;
+          }
+        }
+
+        const b = createIdentifier<A>('b');
+
+        const j = new Injector();
+        j.add([A]);
+        j.add([b, { useExisting: A }]);
+
+        expect(j.get(b)).toBe(j.get(A));
+        expect(j.get(b)).toBeInstanceOf(A);
+        expect(initCount).toBe(1);
+      });
     });
 
     describe('async item', () => {

--- a/src/dependencyItem.ts
+++ b/src/dependencyItem.ts
@@ -317,6 +317,28 @@ export type SyncDependencyItem<T> =
  */
 export type DependencyItem<T> = SyncDependencyItem<T> | AsyncDependencyItem<T>;
 
+/**
+ * Type guard to check if a value is any kind of declarative {@link DependencyItem}.
+ *
+ * Use this to distinguish a declarative descriptor (`{ useClass }`,
+ * `{ useFactory }`, `{ useValue }`, `{ useExisting }`, `{ useAsync }`)
+ * from a pre-constructed instance.
+ *
+ * @param thing - The value to check.
+ * @returns `true` if the value is a `DependencyItem` of any variant.
+ */
+export function isDependencyItem<T>(
+  thing: unknown,
+): thing is DependencyItem<T> {
+  return (
+    isClassDependencyItem(thing) ||
+    isFactoryDependencyItem(thing) ||
+    isValueDependencyItem(thing) ||
+    isExistingDependencyItem(thing) ||
+    isAsyncDependencyItem(thing)
+  );
+}
+
 export function prettyPrintIdentifier<T>(id: DependencyIdentifier<T>): string {
   return isCtor(id) && !(id as any)[IdentifierDecoratorSymbol]
     ? id.name

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -32,6 +32,7 @@ import {
   isAsyncHook,
   isClassDependencyItem,
   isCtor,
+  isDependencyItem,
   isExistingDependencyItem,
   isFactoryDependencyItem,
   isValueDependencyItem,
@@ -345,12 +346,7 @@ export class Injector {
     if (typeof item === 'undefined') {
       // Add dependency
       this.dependencyCollection.add(identifierOrCtor as Ctor<T>);
-    } else if (
-      isAsyncDependencyItem(item) ||
-      isClassDependencyItem(item) ||
-      isValueDependencyItem(item) ||
-      isFactoryDependencyItem(item)
-    ) {
+    } else if (isDependencyItem(item)) {
       // Add dependency
       this.dependencyCollection.add(
         identifierOrCtor,

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -19,6 +19,7 @@ export {
   isAsyncHook,
   isClassDependencyItem,
   isCtor,
+  isDependencyItem,
   isFactoryDependencyItem,
   isValueDependencyItem,
   type SyncDependencyItem,


### PR DESCRIPTION
## Summary

Fix #56: `Injector.add([id, { useExisting: target }])` previously stored the literal descriptor in `resolvedDependencyCollection` instead of creating an alias, because the dispatch chain in `add()` did not check for existing items. `injector.get(id)` therefore returned the `{ useExisting }` object verbatim rather than resolving the alias.

Per the maintainer's suggestion on the issue, this PR extracts a single `isDependencyItem` type guard in `dependencyItem.ts` covering every declarative variant (class/factory/value/existing/async) and uses it from `add()`. The constructor path was already correct; `add()` now matches its behavior.

### Why a new guard rather than `||`-ing in `isExistingDependencyItem`

The existing per-variant guards (`isClassDependencyItem`, `isExistingDependencyItem`, ...) are kept — `_resolveDependency()` still needs them to dispatch each item to the right resolver. `add()` has a different question to answer: "is this a declarative descriptor (defer to resolution) or a pre-built instance (cache as-is)?" The new `isDependencyItem` is the natural shape for that one question, and replaces the brittle 4-line `||` chain that silently omitted `useExisting`.

## Changes

- `src/dependencyItem.ts` — add and export `isDependencyItem` covering all five variants
- `src/injector.ts` — replace the `||` chain in `add()` with `isDependencyItem(item)`
- `src/publicApi.ts` — export `isDependencyItem` alongside the other `is*DependencyItem` guards
- `src/__tests__/core.spec.ts` — add a regression test under `existing item`

## Test plan

- [x] New regression test `should resolve as an alias when registered via Injector.add` (asserts both alias identity and `instanceof`)
- [x] `bun test` — 97 pass, 0 fail
- [x] `bun run coverage` — `src/dependencyItem.ts` and `src/injector.ts` both at 100% line + function coverage; no regression vs. `main`
- [x] `bun run lint`, `bun run build` — clean